### PR TITLE
Fixed typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ to specify all instances of a given ``Schema`` should be optimized:
 
     class ArtistSchema(Schema):
         class Meta:
-            jit = toastedMarshmallow.Jit
+            jit = toastedmarshmallow.Jit
         name = fields.Str()
 
 You can also enable Toasted Marshmallow globally by setting the environment


### PR DESCRIPTION
Everywhere else in the file it's written as one word.