### PR TITLE
Add six as install req in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
     extras_require={'reco': EXTRA_REQUIREMENTS},
     license='apache2',
     install_requires=[
-        'attrs >= 17.1.0'
+        'attrs >= 17.1.0',
+        'six'
     ],
     zip_safe=False,
     keywords=(


### PR DESCRIPTION
I was creating a conda-forge package for `toastedmarshmallow` (https://github.com/conda-forge/staged-recipes/pull/4461), and noticed that `six` is used:

https://github.com/lyft/toasted-marshmallow/search?utf8=%E2%9C%93&q=six&type=

but not included in the `setup.py` under `install_requires`. This PR adds the requirement. 