### PR TITLE
bump submodule to lyft's 2.15.1 changes 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
   - pip install -r dev-requirements.txt
   - python setup.py install
   - if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install mypy; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != "pypy" ]]; then pip install cython; fi
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then mypy --ignore-missing-imports --follow-imports=silent --python-version=3.6 --warn-no-return --strict-optional toastedmarshmallow tests; fi

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,7 @@ without having to sacrifice performance!
     Benchmark Result:
       Original Time: 2682.61 usec/dump
       Optimized Time: 176.38 usec/dump
-      Optimized (Cython) Time: 125.77 usec/dump
       Speed up: 15.21x
-      Cython Speed up: 21.33x
 
 Even ``PyPy`` benefits from ``toastedmarshmallow``!
 
@@ -140,17 +138,3 @@ Toastedmarshmallow will invoke the proper serializer based upon the input.
 Since Toastedmarshmallow is generating code at runtime, it's critical you
 re-use Schema objects.  If you're creating a new Schema object every time you
 serialize/deserialize an object you'll likely have much worse performance.
-
-:zap::microscope: Experimental :microscope::zap:
---------------------------------------------------
-
-Toastedmarshmallow also has an experimental Cython based jit.  It takes the
-generated code above and runs it through Cython first, getting another 1.5x
-win.  Generally the generated Python code is fast enough, but this is a useful
-option when you've got to squeeze out every last bit of performance.
-
-To use the Cython jit, replace `Jit` with `CythonJit`:
-
-.. code-block:: python
-
-    schema.jit = toastedmarshmallow.CythonJit

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ pytest==3.0.7
 pytest-cov==2.5.1
 python-coveralls==2.9.1
 pylint==1.7.1
-astroid==1.6.6
+astroid==1.5.3
 python-dateutil==2.6.1
 pytz==2017.2
 simplejson==3.11.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ pytest==3.0.7
 pytest-cov==2.5.1
 python-coveralls==2.9.1
 pylint==1.7.1
-astroid==2.2.5
+astroid==1.6.6
 python-dateutil==2.6.1
 pytz==2017.2
 simplejson==3.11.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ pytest==3.0.7
 pytest-cov==2.5.1
 python-coveralls==2.9.1
 pylint==1.7.1
+astroid==2.2.5
 python-dateutil==2.6.1
 pytz==2017.2
 simplejson==3.11.1

--- a/performance/benchmark.py
+++ b/performance/benchmark.py
@@ -10,7 +10,7 @@ import gc
 import time
 import timeit
 from marshmallow import Schema, fields, ValidationError
-from toastedmarshmallow import CythonJit, Jit
+from toastedmarshmallow import Jit
 
 
 # Custom validator
@@ -83,13 +83,10 @@ class Quote(object):
 
 
 def run_timeit(quotes, iterations, repeat, jit=False, load=False,
-               cython=False, profile=False):
+               profile=False):
     quotes_schema = QuoteSchema(many=True)
     if jit:
-        if cython:
-            quotes_schema.jit = CythonJit
-        else:
-            quotes_schema.jit = Jit
+        quotes_schema.jit = Jit
     if profile:
         profile = cProfile.Profile()
         profile.enable()
@@ -146,37 +143,19 @@ def main():
     optimized_dump_time = run_timeit(quotes, args.iterations, args.repeat,
                                      load=False, jit=True,
                                      profile=args.profile)
-    cython_dump_time = run_timeit(quotes, args.iterations, args.repeat,
-                                  load=False, jit=True, cython=True,
-                                  profile=args.profile)
     optimized_load_time = run_timeit(quotes, args.iterations, args.repeat,
                                      load=True, jit=True, profile=args.profile)
-    cython_load_time = run_timeit(quotes, args.iterations, args.repeat,
-                                  load=True, jit=True, cython=True,
-                                  profile=args.profile)
     print('Benchmark Result:')
     print('\tOriginal Dump Time: {0:.2f} usec/dump'.format(original_dump_time))
     print('\tOptimized Dump Time: {0:.2f} usec/dump'.format(
         optimized_dump_time))
-    print('\tOptimized (Cython) Dump Time: {0:.2f} usec/dump'.format(
-        cython_dump_time))
     print('\tOriginal Load Time: {0:.2f} usec/load'.format(original_load_time))
     print('\tOptimized Load Time: {0:.2f} usec/load'.format(
         optimized_load_time))
-    print('\tOptimized (Cython) Time: {0:.2f} usec/load'.format(
-        cython_load_time))
     print('\tSpeed up for dump: {0:.2f}x'.format(
         original_dump_time / optimized_dump_time))
-    print('\tCython Speed up for dump: {0:.2f}x'.format(
-        original_dump_time / cython_dump_time))
-    print('\tCython Speed up over Python Jit for dump: {0:.2f}x'.format(
-        optimized_dump_time / cython_dump_time))
     print('\tSpeed up for load: {0:.2f}x'.format(
         original_load_time / optimized_load_time))
-    print('\tCython Speed up for load: {0:.2f}x'.format(
-        original_load_time / cython_load_time))
-    print('\tCython Speed up over Python Jit for load: {0:.2f}x'.format(
-        optimized_load_time / cython_load_time))
 
 
 if __name__ == '__main__':

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -318,9 +318,8 @@ def test_jit_bails_nested_attribute():
     assert marshal_method is None
 
 
-@pytest.mark.parametrize('use_cython', [True, False])
-def test_jitted_marshal_method(schema, use_cython):
-    context = JitContext(use_cython=use_cython)
+def test_jitted_marshal_method(schema):
+    context = JitContext()
     marshal_method = generate_marshall_method(schema, threshold=1,
                                               context=context)
     result = marshal_method({
@@ -344,10 +343,8 @@ def test_jitted_marshal_method(schema, use_cython):
     assert marshal_method.proxy._call == marshal_method.proxy.dict_serializer
 
 
-@pytest.mark.skip(reason="roy what is going on")
-@pytest.mark.parametrize('use_cython', [True, False])
-def test_jitted_unmarshal_method(schema, use_cython):
-    context = JitContext(use_cython=use_cython)
+def test_jitted_unmarshal_method(schema):
+    context = JitContext()
     unmarshal_method = generate_unmarshall_method(schema, context=context)
     result = unmarshal_method({
         'foo': 32,

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -344,6 +344,7 @@ def test_jitted_marshal_method(schema, use_cython):
     assert marshal_method.proxy._call == marshal_method.proxy.dict_serializer
 
 
+@pytest.mark.skip(reason="roy what is going on")
 @pytest.mark.parametrize('use_cython', [True, False])
 def test_jitted_unmarshal_method(schema, use_cython):
     context = JitContext(use_cython=use_cython)

--- a/tests/test_toasted_marshmallow.py
+++ b/tests/test_toasted_marshmallow.py
@@ -12,10 +12,8 @@ def schema():
     return TestSchema()
 
 
-@pytest.mark.parametrize('jit', [toastedmarshmallow.Jit,
-                                 toastedmarshmallow.CythonJit])
-def test_marshmallow_integration_dump(schema, jit):
-    schema.jit = jit
+def test_marshmallow_integration_dump(schema):
+    schema.jit = toastedmarshmallow.Jit
     assert schema._jit_instance is not None
 
     result = schema.dump({'key': 'hello', 'value': 32})
@@ -29,10 +27,8 @@ def test_marshmallow_integration_dump(schema, jit):
     assert schema._jit_instance is not None
 
 
-@pytest.mark.parametrize('jit', [toastedmarshmallow.Jit,
-                                 toastedmarshmallow.CythonJit])
-def test_marshmallow_integration_load(schema, jit):
-    schema.jit = jit
+def test_marshmallow_integration_load(schema):
+    schema.jit = toastedmarshmallow.Jit
     assert schema._jit_instance is not None
 
     result = schema.load({'key': 'hello', 'value': 32})
@@ -45,10 +41,8 @@ def test_marshmallow_integration_load(schema, jit):
     assert schema._jit_instance is not None
 
 
-@pytest.mark.parametrize('jit', [toastedmarshmallow.Jit,
-                                 toastedmarshmallow.CythonJit])
-def test_marshmallow_integration_invalid_data(schema, jit):
-    schema.jit = jit
+def test_marshmallow_integration_invalid_data(schema):
+    schema.jit = toastedmarshmallow.Jit
     assert schema._jit_instance is not None
     result = schema.dump({'key': 'hello', 'value': 'foo'})
     assert {'value': ['Not a valid integer.']} == result.errors

--- a/toastedmarshmallow/__init__.py
+++ b/toastedmarshmallow/__init__.py
@@ -10,13 +10,13 @@ __version__ = '0.2.6'
 
 
 class Jit(SchemaJit):
-    def __init__(self, schema, use_cython=False):
+    def __init__(self, schema):
         super(Jit, self).__init__(schema)
         self.schema = schema
         self.marshal_method = generate_marshall_method(
-            schema, context=JitContext(use_cython=use_cython))
+            schema, context=JitContext())
         self.unmarshal_method = generate_unmarshall_method(
-            schema, context=JitContext(use_cython=use_cython))
+            schema, context=JitContext())
 
     @property
     def jitted_marshal_method(self):
@@ -25,8 +25,3 @@ class Jit(SchemaJit):
     @property
     def jitted_unmarshal_method(self):
         return self.unmarshal_method
-
-
-class CythonJit(Jit):
-    def __init__(self, schema):
-        super(CythonJit, self).__init__(schema, use_cython=True)

--- a/toastedmarshmallow/jit.py
+++ b/toastedmarshmallow/jit.py
@@ -352,9 +352,9 @@ def _should_skip_field(field_name, field_obj, context):
             not bool(field_obj.deserialize_method_name)
         )
 
-    if (load_only and context.is_serializing):
+    if load_only and context.is_serializing:
         return True
-    if (dump_only and not context.is_serializing):
+    if dump_only and not context.is_serializing:
         return True
     if context.only and field_name not in context.only:
         return True

--- a/toastedmarshmallow/jit.py
+++ b/toastedmarshmallow/jit.py
@@ -13,9 +13,6 @@ from .compat import is_overridden
 from .utils import IndentedString
 
 
-CYTHON_AVAILABLE = False
-
-
 # Regular Expression for identifying a valid Python identifier name.
 _VALID_IDENTIFIER = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*')
 
@@ -174,7 +171,6 @@ class JitContext(object):
 
     """
     namespace = attr.ib(default={})  # type: Dict[str, Any]
-    use_cython = attr.ib(default=False)  # type: bool
     use_inliners = attr.ib(default=True)  # type: bool
     schema_stack = attr.ib(default=attr.Factory(set))  # type: Set[str]
     only = attr.ib(default=None)  # type: Optional[Set[str]]
@@ -631,7 +627,6 @@ def generate_marshall_method(schema, context=missing, threshold=100):
     :param schema: The Schema to generate a marshall method for.
     :param threshold: The number of calls of the same type to observe before
         specializing the marshal method for that type.
-    :param use_cython: Whether or not to attempt to use cython when Jitting.
     :return: A Callable that can be used to marshall objects for the schema
     """
     if is_overridden(schema.get_attribute, Schema.get_attribute):


### PR DESCRIPTION
depends on commits over [here](https://github.com/lyft/marshmallow/releases/tag/2.15.1)
```bash
(venv)~/toasted-marshmallow [bump-submod*] python performance/benchmark.py 
Benchmark Result:
	Original Dump Time: 1692.94 usec/dump
	Optimized Dump Time: 243.34 usec/dump
	Original Load Time: 1092.35 usec/load
	Optimized Load Time: 238.99 usec/load
	Speed up for dump: 6.96x
	Speed up for load: 4.57x
```