### PR TITLE
Fix optimizations of dumping None Numbers.

### DIFF
--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -442,7 +442,9 @@ def test_instance_jitted_instance_marshal_method(simple_schema,
             marshal_method.proxy.instance_serializer)
 
 
-def test_instance_jitted_instance_marshal_method_supports_none_int(simple_schema, simple_object):
+def test_instance_jitted_instance_marshal_method_supports_none_int(
+        simple_schema, simple_object
+):
     simple_object.value = None
     marshal_method = generate_marshall_method(simple_schema)
     result = marshal_method(simple_object)
@@ -451,7 +453,6 @@ def test_instance_jitted_instance_marshal_method_supports_none_int(simple_schema
         'value': None
     }
     assert expected == result
-
 
 
 def test_optimized_jitted_marshal_method(optimized_schema, simple_object):

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -183,7 +183,7 @@ def InstanceSerializer(obj):
         'if "@#" in obj:\n'
         '        value = obj["@#"]; '
         'value = value() if callable(value) else value; '
-        'value = int(value); '
+        'value = int(value) if value is not None else None; '
         'res["foo"] = value')
     bar_assignment = (
         'value = obj.bar; '
@@ -220,13 +220,13 @@ def test_generate_marshall_method_bodies():
 def InstanceSerializer(obj):
     res = {}
     value = obj.foo; value = value() if callable(value) else value; \
-value = int(value); res["foo"] = value
+value = int(value) if value is not None else None; res["foo"] = value
     return res
 def DictSerializer(obj):
     res = {}
     if "foo" in obj:
         value = obj["foo"]; value = value() if callable(value) else value; \
-value = int(value); res["foo"] = value
+value = int(value) if value is not None else None; res["foo"] = value
     return res
 def HybridSerializer(obj):
     res = {}
@@ -235,7 +235,7 @@ def HybridSerializer(obj):
     except (KeyError, AttributeError, IndexError, TypeError):
         value = obj.foo
     value = value; value = value() if callable(value) else value; \
-value = int(value); res["foo"] = value
+value = int(value) if value is not None else None; res["foo"] = value
     return res'''
     assert expected == result
 
@@ -440,6 +440,18 @@ def test_instance_jitted_instance_marshal_method(simple_schema,
     assert simple_dict == result
     assert (marshal_method.proxy._call ==
             marshal_method.proxy.instance_serializer)
+
+
+def test_instance_jitted_instance_marshal_method_supports_none_int(simple_schema, simple_object):
+    simple_object.value = None
+    marshal_method = generate_marshall_method(simple_schema)
+    result = marshal_method(simple_object)
+    expected = {
+        'key': 'some_key',
+        'value': None
+    }
+    assert expected == result
+
 
 
 def test_optimized_jitted_marshal_method(optimized_schema, simple_object):

--- a/toastedmarshmallow/__init__.py
+++ b/toastedmarshmallow/__init__.py
@@ -6,7 +6,7 @@ from .jit import (
     JitContext
 )
 
-__version__ = '2.15.2'
+__version__ = '2.15.2post1'
 
 
 class Jit(SchemaJit):

--- a/toastedmarshmallow/jit.py
+++ b/toastedmarshmallow/jit.py
@@ -255,7 +255,7 @@ class NumberInliner(FieldInliner):
         result = field.num_type.__name__ + '({0})'
         if field.as_string and context.is_serializing:
             result = 'str({0})'.format(result)
-        if field.allow_none is True:
+        if field.allow_none is True or context.is_serializing:
             # Only emit the Null checking code if nulls are allowed.  If they
             # aren't allowed casting `None` to an integer will throw and the
             # slow path will take over.


### PR DESCRIPTION
Marshmallow only validates `allow_none` on deserialize, not serialize.  This was causing optimizations
to fail if a `int` value was `None` on serialization.