### PR TITLE
Fix case in the toastedmarshmallow module name in the README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ to specify all instances of a given ``Schema`` should be optimized:
 
     class ArtistSchema(Schema):
         class Meta:
-            jit = toastedMarshmallow.Jit
+            jit = toastedmarshmallow.Jit
         name = fields.Str()
 
 You can also enable Toasted Marshmallow globally by setting the environment


### PR DESCRIPTION
In the README example`toastedmarshmallow` imported but used with capital case **M** `toastedMarshmallow.Jit`, I fixed that to a lower case `toastedmarshmallow.Jit`